### PR TITLE
build: downgrade slf4j api to 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <reactor.version>3.5.10</reactor.version>
-        <slf4j-api.version>2.0.9</slf4j-api.version>
+        <slf4j-api.version>1.7.36</slf4j-api.version>
         <sortpom-maven-plugin.version>3.3.0</sortpom-maven-plugin.version>
         <spotless-maven-plugin.version>2.38.0</spotless-maven-plugin.version>
         <testcontainers.version>1.19.0</testcontainers.version>

--- a/src/main/java/org/neo4j/cdc/client/CDCClient.java
+++ b/src/main/java/org/neo4j/cdc/client/CDCClient.java
@@ -164,6 +164,6 @@ public class CDCClient implements CDCService {
                         RxSession::close)
                 .doOnSubscribe(s -> log.trace("subscribed to {}", description))
                 .doOnSuccess(c -> log.trace("subscription to {} completed with '{}'", description, c))
-                .doOnError(t -> log.atError().setCause(t).log("subscription to {} failed", description));
+                .doOnError(t -> log.error("subscription to {} failed", description, t));
     }
 }


### PR DESCRIPTION
Downgrade slf4j api to 1.7 version instead of 2.0 so that it matches what we get with Kafka Connect.