### PR TITLE
build: use slim package for neo4j driver

### DIFF
--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -6,7 +6,14 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 Apache Software License, Version 2.0
   Apache Commons Collections
   JetBrains Java Annotations
-  Neo4j Java Driver
+  Netty/Buffer
+  Netty/Codec
+  Netty/Common
+  Netty/Handler
+  Netty/Resolver
+  Netty/TomcatNative [OpenSSL - Classes]
+  Netty/Transport
+  Netty/Transport/Native/Unix/Common
   Non-Blocking Reactive Foundation for the JVM
 ------------------------------------------------------------------------------
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -21,7 +21,14 @@ Third-party licenses
 Apache Software License, Version 2.0
   Apache Commons Collections
   JetBrains Java Annotations
-  Neo4j Java Driver
+  Netty/Buffer
+  Netty/Codec
+  Netty/Common
+  Netty/Handler
+  Netty/Resolver
+  Netty/TomcatNative [OpenSSL - Classes]
+  Netty/Transport
+  Netty/Transport/Native/Unix/Common
   Non-Blocking Reactive Foundation for the JVM
 
 BSD License

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <neo4j-java-driver.version>4.4.18</neo4j-java-driver.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <reactive-streams.version>1.0.4</reactive-streams.version>
-        <reactor.version>3.7.0</reactor.version>
+        <reactor-release-train.version>2024.0.0</reactor-release-train.version>
         <slf4j-api.version>1.7.36</slf4j-api.version>
         <sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>
         <spotless-maven-plugin.version>2.43.0</spotless-maven-plugin.version>
@@ -70,6 +70,13 @@
     </properties>
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>io.projectreactor</groupId>
+                <artifactId>reactor-bom</artifactId>
+                <version>${reactor-release-train.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.reactivestreams</groupId>
                 <artifactId>reactive-streams</artifactId>
@@ -81,7 +88,6 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
-            <version>${reactor.version}</version>
         </dependency>
         <dependency>
             <groupId>org.antlr</groupId>
@@ -100,7 +106,7 @@
         </dependency>
         <dependency>
             <groupId>org.neo4j.driver</groupId>
-            <artifactId>neo4j-java-driver</artifactId>
+            <artifactId>neo4j-java-driver-slim</artifactId>
             <version>${neo4j-java-driver.version}</version>
         </dependency>
         <dependency>
@@ -111,7 +117,6 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
-            <version>${reactor.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -214,7 +219,7 @@
                     <failIfMissing>true</failIfMissing>
                     <plainTextReport>true</plainTextReport>
                     <prependText>${licensing.prepend.text}</prependText>
-                    <excludedGroups>^((org.neo4j.cdc.client){1})$</excludedGroups>
+                    <excludedGroups>^((org.neo4j.cdc.client|org.neo4j.driver){1})$</excludedGroups>
                     <includedScopes>compile,runtime</includedScopes>
                 </configuration>
                 <dependencies>


### PR DESCRIPTION
This PR;

- switches neo4j driver to the slim package,
- resolves dependency conflict by importing reactor-bom release train pom,
- updates license notices.