### PR TITLE
fix: bump qs to 6.15.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1848,9 +1848,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   },
   "scripts": {
     "prepare": "husky"
+  },
+  "overrides": {
+    "qs": "6.15.2"
   }
 }


### PR DESCRIPTION
Bumps transitive `qs` dependency to 6.15.2 via npm `overrides` to resolve the Semgrep supply chain finding.

Dependency path: `danger` → `@gitbeaker/rest` → `@gitbeaker/requester-utils` → `qs`

There is no new danger-js release that includes a `qs` update (latest is 13.0.5), so a manual `overrides` entry is required to force the safe version.

Closes CONN-1015