### PR TITLE
build: update undici version to 6.27.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2051,11 +2051,10 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "prepare": "husky"
   },
   "overrides": {
-    "qs": "6.15.2"
+    "danger": {
+      "undici": "6.27.0"
+    }
   }
 }


### PR DESCRIPTION
Bump undici to 6.27 to resolve danger.js CVEs complaints.