### PR TITLE
ci: add known ignored dependencies to dependabot for v1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,17 @@ updates:
       default-days: 3
     open-pull-requests-limit: 10
     target-branch: "main"
+    ignore:
+      # requires JVM 17
+      - dependency-name: "org.junit.jupiter:junit-jupiter"
+        versions: "[6.0.1,)"
+      # requires JVM 17
+      - dependency-name: "com.diffplug.spotless:spotless-maven-plugin"
+        versions: "[3.0.0,)"
+      # pin 4.1.x for compatibility with Neo4j Kafka Connector v5
+      - dependency-name: "io.netty:netty-bom"
+        versions: "[4.2.15.Final,)"
+
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
@@ -16,6 +27,7 @@ updates:
       default-days: 3
     open-pull-requests-limit: 10
     target-branch: "2.0"
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -25,6 +37,7 @@ updates:
     groups:
       dev-deps:
         dependency-type: "development"
+
     target-branch: "main"
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
Add known versions that 1.0 version of CDC client doesn't support. 